### PR TITLE
Update combined.min.js

### DIFF
--- a/js/combined.min.js
+++ b/js/combined.min.js
@@ -9,7 +9,7 @@ t["_"+a]=1,(a===s?!h:h)&&(setTimeout(function(){e(t).triggerHandler(a===s?s:l)},
 e.sonar=d,c[l]=[],e.event.special[l]={add:function(e){var t=e.data||{},n=this
 n[l]||m(this,{px:t.distance,full:t.full,evt:l})},remove:function(){h(this,l)}},c[s]=[],e.event.special[s]={add:function(e){var t=e.data||{},n=this
 n[s]||m(n,{px:t.distance,full:t.full,evt:s})},remove:function(){h(this,s)}}}(jQuery,window,document)
-var BJLL=BJLL||{}
+var BJLL=BJLL||{};
 !function(e){function t(){var t=200
 void 0!==BJLL.threshold&&(t=parseInt(BJLL.threshold)),e(".lazy-hidden").not(".data-lazy-ready").one("scrollin.bj_lazy_load",{distance:t},function(){var t=e(this),o=t.attr("data-lazy-type")
 if("image"==o){var r=t.attr("data-lazy-src")


### PR DESCRIPTION
Adding this semi colon fixes the the critical error that occurs when viewing pages on sprint network. The sprint broadband network modifies the code, which sometimes indiscriminately removes white space...which was making this plugin not work on sprint devices in network data mode.