### PR TITLE
FIX: Grab the whole iFrame code, with the close tag

### DIFF
--- a/bj-lazy-load.php
+++ b/bj-lazy-load.php
@@ -212,7 +212,7 @@ if ( ! class_exists( 'BJLL' ) ) {
 		protected function _filter_iframes( $content ) {
 		
 			$matches = array();
-			preg_match_all( '/<iframe\s+.*?>/', $content, $matches );
+			preg_match_all( '|<iframe\s+.*?</iframe>|siU', $content, $matches );
 			
 			$search = array();
 			$replace = array();


### PR DESCRIPTION
BJLL didn't grab the whole iframe code, only the opening tag.
What happens is the closing tag and any content inside the iframe is not captured.
This causes browsers to display any content inside the iframe even though the browser supports iframes.

This modification to the regex fixes that.