### PR TITLE
FIX: Ignore filtering noscript tags

### DIFF
--- a/bj-lazy-load.php
+++ b/bj-lazy-load.php
@@ -170,9 +170,12 @@ if ( ! class_exists( 'BJLL' ) ) {
 		}
 		
 		protected function _filter_images( $content ) {
-		
+
+			// Make sure we don't mess with the contents of <noscript>
+			$match_content = $this->remove_noscript($content);
+
 			$matches = array();
-			preg_match_all( '/<img[\s\r\n]+.*?>/is', $content, $matches );
+			preg_match_all( '/<img[\s\r\n]+.*?>/is', $match_content, $matches );
 			
 			$search = array();
 			$replace = array();
@@ -210,9 +213,12 @@ if ( ! class_exists( 'BJLL' ) ) {
 		}
 		
 		protected function _filter_iframes( $content ) {
-		
+
+			// Make sure we don't mess with the contents of <noscript>
+			$match_content = $this->remove_noscript($content);
+
 			$matches = array();
-			preg_match_all( '/<iframe\s+.*?>/', $content, $matches );
+			preg_match_all( '/<iframe\s+.*?>/', $match_content, $matches );
 			
 			$search = array();
 			$replace = array();
@@ -235,6 +241,10 @@ if ( ! class_exists( 'BJLL' ) ) {
 			$content = str_replace( $search, $replace, $content );
 			
 			return $content;
+		}
+		
+		protected function remove_noscript($content) {
+			return preg_replace('/<noscript.*?(\/noscript>)/', '', $content);
 		}
 		
 		protected static function _get_options() {


### PR DESCRIPTION
Currently, BJLL will filter content inside noscript tags.
This is not good since content inside noscript tags can't be lazy loaded (noscript is for browsers with javascript off).

This fix makes sure that content with noscript tags isn't touched.