### PR TITLE
DON'T BE GREEDY regular expression fix ..

### DIFF
--- a/bj-lazy-load.php
+++ b/bj-lazy-load.php
@@ -227,7 +227,7 @@ if ( ! class_exists( 'BJLL' ) ) {
 			$match_content = $this->remove_noscript($content);
 
 			$matches = array();
-			preg_match_all( '|<iframe\s+.*?</iframe>|siU', $match_content, $matches );
+			preg_match_all( '|<iframe\s+.*</iframe>|siU', $match_content, $matches );
 			
 			$search = array();
 			$replace = array();


### PR DESCRIPTION
The regular expression (that I wrote) on line 230 was too greedy.
If the U modifier is used then this is ungreedy by default.
The problem is when you have the question mark behind a quantifier then it will inverse that quantifier's greediness.
So it will search for an iframe open tag, then search for the last iframe close tag (rather than the next iframe close tag).
** ORIGINAL REGEXP **
|<iframe\s+.*?</iframe>|siU

By removing the question mark, the whole expression is not greedy by default, resulting in functionality just like you'd want.
** FIXED REGEXP **
|<iframe\s+.*</iframe>|siU