### PR TITLE
L10n update

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -5,7 +5,7 @@ class BJLL_Admin_Page extends scbAdminPage {
 	function setup() {
 		$this->args = array(
 			'menu_title' => 'BJ Lazy Load',
-			'page_title' => __( 'BJ Lazy Load Options', 'bj-lazy-load' ),
+			'page_title' => 'BJ Lazy Load Options',
 		);
 	}
 	

--- a/lang/bj-lazy-load.pot
+++ b/lang/bj-lazy-load.pot
@@ -31,6 +31,10 @@ msgid "No"
 msgstr ""
 
 #: admin.php:23
+msgid "Apply to text widgets"
+msgstr ""
+
+#: admin.php:29
 msgid "Apply to post thumbnails"
 msgstr ""
 

--- a/scb/AdminPage.php
+++ b/scb/AdminPage.php
@@ -463,7 +463,7 @@ abstract class scbAdminPage {
 			'menu_title'            => $this->args['page_title'],
 			'page_slug'             => '',
 			'nonce'                 => '',
-			'action_link'           => __( 'Settings', $this->textdomain ),
+			'action_link'           => 'Settings',
 			'admin_action_priority' => 10,
 		) );
 
@@ -511,7 +511,7 @@ abstract class scbAdminPage {
 	function _action_link( $links ) {
 		$url = add_query_arg( 'page', $this->args['page_slug'], admin_url( $this->args['parent'] ) );
 
-		$links[] = html_link( $url, $this->args['action_link'] );
+		$links[] = html_link( $url, __( $this->args['action_link'] ) );
 
 		return $links;
 	}

--- a/scb/AdminPage.php
+++ b/scb/AdminPage.php
@@ -160,7 +160,7 @@ abstract class scbAdminPage {
 	function page_header() {
 		echo "<div class='wrap'>\n";
 		screen_icon( $this->args['screen_icon'] );
-		echo html( 'h2', $this->args['page_title'] );
+		echo html( 'h2', __( $this->args['page_title'], 'bj-lazy-load' ) );
 	}
 
 	/**
@@ -409,7 +409,7 @@ abstract class scbAdminPage {
 		if ( ! $this->args['toplevel'] ) {
 			$this->pagehook = add_submenu_page(
 				$this->args['parent'],
-				$this->args['page_title'],
+				__( $this->args['page_title'], 'bj-lazy-load' ),
 				$this->args['menu_title'],
 				$this->args['capability'],
 				$this->args['page_slug'],
@@ -418,7 +418,7 @@ abstract class scbAdminPage {
 		} else {
 			$func = 'add_' . $this->args['toplevel'] . '_page';
 			$this->pagehook = $func(
-				$this->args['page_title'],
+				__( $this->args['page_title'], 'bj-lazy-load' ),
 				$this->args['menu_title'],
 				$this->args['capability'],
 				$this->args['page_slug'],
@@ -429,7 +429,7 @@ abstract class scbAdminPage {
 
 			add_submenu_page(
 				$this->args['page_slug'],
-				$this->args['page_title'],
+				__( $this->args['page_title'], 'bj-lazy-load' ),
 				$this->args['submenu_title'],
 				$this->args['capability'],
 				$this->args['page_slug'],

--- a/scb/AdminPage.php
+++ b/scb/AdminPage.php
@@ -224,7 +224,7 @@ abstract class scbAdminPage {
 	 */
 	function admin_msg( $msg = '', $class = 'updated' ) {
 		if ( empty( $msg ) )
-			$msg = __( 'Settings <strong>saved</strong>.', $this->textdomain );
+			$msg = __( 'Settings <strong>saved</strong>.', 'bj-lazy-load' );
 
 		echo scb_admin_notice( $msg, $class );
 	}


### PR DESCRIPTION
Updated l10n:
- some phrases were not translated when using translation,
- updated .pot with one new phrase,
- changed one phrase to get translation from global WP translations (by the way it wasn't existed in .pot file).