### PR TITLE
Prevent Undefined index: HTTP_USER_AGENT for opera-mini.php

### DIFF
--- a/inc/compat/opera-mini.php
+++ b/inc/compat/opera-mini.php
@@ -1,7 +1,7 @@
 <?php
 
 function bjll_compat_operamini() {
-	if ( false !== strpos( $_SERVER['HTTP_USER_AGENT'], 'Opera Mini' ) ) {
+	if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && false !== strpos( $_SERVER['HTTP_USER_AGENT'], 'Opera Mini' ) ) {
 		add_filter( 'bjll/enabled', '__return_false' );
 	}
 }


### PR DESCRIPTION
Hi,

My `debug.log` was spammed by
`[30-Sep-2015 07:20:07 UTC] PHP Notice:  Undefined index: HTTP_USER_AGENT in /home/zschocianow/ftp/wordpress/wp-content/plugins/bj-lazy-load/inc/compat/opera-mini.php on line 4`, so `isset()` should fix issue generated by such untypical users.

Greetings