### PR TITLE
Avoid running unnecessary regexp

### DIFF
--- a/src/inc/class-bjll.php
+++ b/src/inc/class-bjll.php
@@ -323,7 +323,10 @@ class BJLL {
 	public static function remove_skip_classes_elements( $content ) {
 
 		$skip_classes = self::_get_skip_classes( 'html' );
-
+		if ( 0 >= count( $skip_classes ) ) {
+			return $content;
+		}
+		
 		/*
 		http://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454
 		We can’t do this, but we still do it.


### PR DESCRIPTION
Avoid running unnecessary regexp if 0 >= $skip_classes